### PR TITLE
Several improvement

### DIFF
--- a/dynoyarn-driver/src/main/java/com/linkedin/dynoyarn/DriverApplicationMaster.java
+++ b/dynoyarn-driver/src/main/java/com/linkedin/dynoyarn/DriverApplicationMaster.java
@@ -605,6 +605,9 @@ public class DriverApplicationMaster {
     Utils.localizeHDFSResource(fs, startScript, Constants.DYARN_START_SCRIPT, LocalResourceType.FILE, containerResources);
     Utils.localizeHDFSResource(fs, containerExecutorCfg, Constants.CONTAINER_EXECUTOR_CFG, LocalResourceType.FILE, containerResources);
 
+    //Try to get Dyno_Generate jar
+    Utils.localizeHDFSResource(fs, System.getenv(Constants.SIMULATED_FATJAR_NAME), Constants.SIMULATED_FATJAR, LocalResourceType.FILE, containerResources);
+
     String hdfsClasspath = System.getenv("HDFS_CLASSPATH");
     for (FileStatus status : fs.listStatus(new Path(hdfsClasspath))) {
       Utils.localizeHDFSResource(fs, status.getPath().toString(), status.getPath().getName(), LocalResourceType.FILE, containerResources);

--- a/dynoyarn-driver/src/main/java/com/linkedin/dynoyarn/workload/WorkloadApplicationMaster.java
+++ b/dynoyarn-driver/src/main/java/com/linkedin/dynoyarn/workload/WorkloadApplicationMaster.java
@@ -469,6 +469,7 @@ public class WorkloadApplicationMaster {
       containerShellEnv.put(Constants.SIMULATED_FATJAR_NAME, System.getenv(Constants.SIMULATED_FATJAR_NAME));
       containerShellEnv.put("HDFS_CLASSPATH", System.getenv("HDFS_CLASSPATH"));
       containerShellEnv.put(Constants.DYARN_CONF_NAME, System.getenv(Constants.DYARN_CONF_NAME));
+      containerShellEnv.put("driverAppId", System.getenv("driverAppId"));
       try (PrintWriter out = new PrintWriter(Constants.SPEC_FILE, "UTF-8")) {
         String spec = new ObjectMapper().writeValueAsString(containerAppSpecs)
             .replaceAll("\"", "'");

--- a/dynoyarn-driver/src/main/java/com/linkedin/dynoyarn/workload/WorkloadClient.java
+++ b/dynoyarn-driver/src/main/java/com/linkedin/dynoyarn/workload/WorkloadClient.java
@@ -66,6 +66,8 @@ public class WorkloadClient implements AutoCloseable {
   private String confPath;
   private String workloadJarPath;
 
+  private String driverAppId;
+
   private Path appResourcesPath;
 
   public static final String DRIVER_APP_ID_ARG = "driver_app_id";
@@ -159,7 +161,8 @@ public class WorkloadClient implements AutoCloseable {
     if (args.length == 0) {
       throw new IllegalArgumentException("No args specified for client to initialize");
     }
-    String driverAppId = cliParser.getOptionValue(DRIVER_APP_ID_ARG);
+    //String driverAppId = cliParser.getOptionValue(DRIVER_APP_ID_ARG);
+    driverAppId = cliParser.getOptionValue(DRIVER_APP_ID_ARG);
     workloadSpecLocation = cliParser.getOptionValue(WORKLOAD_SPEC_LOCATION_ARG);
     simulatedFatJarLocation = cliParser.getOptionValue(SIMULATED_FATJAR_ARG);
     confPath = cliParser.getOptionValue(CONF_ARG);
@@ -243,6 +246,7 @@ public class WorkloadClient implements AutoCloseable {
       classPathEnv.append(c.trim());
     }
     containerEnv.put("CLASSPATH", classPathEnv.toString());
+    containerEnv.put("driverAppId", driverAppId);
 
     // Set logs to be readable by everyone. Set app to be modifiable only by app owner.
     Map<ApplicationAccessType, String> acls = new HashMap<>(2);

--- a/dynoyarn-driver/src/main/resources/start-component.sh
+++ b/dynoyarn-driver/src/main/resources/start-component.sh
@@ -123,6 +123,7 @@ if [ "$component" = "RESOURCE_MANAGER" ]; then
   cp `readlink -f dynoyarn-capacity-scheduler.xml` ${baseDir}/dcs/capacity-scheduler.xml
   rm ${confDir}/capacity-scheduler.xml
   ln -s ${baseDir}/dcs/capacity-scheduler.xml ${confDir}/capacity-scheduler.xml
+  unset APPLICATION_WEB_PROXY_BASE
 else
   rm ${hadoopHome}/etc/hadoop/container-executor.cfg
   ln -s `readlink -f dynoyarn-container-executor.cfg` ${hadoopHome}/etc/hadoop/container-executor.cfg

--- a/dynoyarn-driver/src/main/resources/start-component.sh
+++ b/dynoyarn-driver/src/main/resources/start-component.sh
@@ -145,6 +145,14 @@ read -r -d '' driverConfigs <<EOF
   $@
 EOF
 
+# When mesher will start node manager, it will download the simulatedfatjar and then put it on the /tmp folder
+# When dynoyarn generator run its container, it doesn't need to download simulatedfatjar itself.
+# Reason we did this is that, dynoyarn generator will run a container without security check, therefore,
+# dynoyarn generator container can't download a file from a security cluster.
+if [ "$component" = "NODE_MANAGER" ]; then
+  rm -f /tmp/simulatedfatjar.jar
+  cp `pwd`/simulatedfatjar.jar /tmp/simulatedfatjar.jar
+
 if [ "$component" = "NODE_MANAGER" ]; then
   HADOOP_LOG_DIR=$logDir HADOOP_CLIENT_OPTS=$HADOOP_CLIENT_OPTS $hadoopHome/bin/hadoop com.linkedin.dynoyarn.SimulatedNodeManagers $driverConfigs $nmCount
   echo nodemanager

--- a/dynoyarn-driver/src/main/resources/start-component.sh
+++ b/dynoyarn-driver/src/main/resources/start-component.sh
@@ -63,7 +63,8 @@ cp *.jar $extraClasspathDir
 
 # This is where libleveldbjni is written (per-NM). Write it to a larger partition
 # instead of /tmp
-tmpdir="/grid/a/tmp/hadoop-`whoami`"
+#tmpdir="/grid/a/tmp/hadoop-`whoami`"
+tmpdir="$baseDir/tmp/hadoop-`whoami`"
 mkdir $tmpdir
 
 # Change environment variables for the Hadoop process

--- a/dynoyarn-generator/src/main/java/com/linkedin/dynoyarn/workload/simulation/SimulatedApplicationMaster.java
+++ b/dynoyarn-generator/src/main/java/com/linkedin/dynoyarn/workload/simulation/SimulatedApplicationMaster.java
@@ -120,8 +120,10 @@ public class SimulatedApplicationMaster {
     InputStream inputStream = fs.open(new Path(clusterSpecLocation));
     String out = IOUtils.toString(inputStream);
     ClusterInfo cluster = new ObjectMapper().readValue(out, ClusterInfo.class);
-    rmEndpoint = cluster.getRmHost() + ":" + cluster.getRmPort();
-    amEndpoint = cluster.getRmHost() + ":" + cluster.getRmSchedulerPort();
+    //rmEndpoint = cluster.getRmHost() + ":" + cluster.getRmPort();
+    //amEndpoint = cluster.getRmHost() + ":" + cluster.getRmSchedulerPort();
+    rmEndpoint = System.getenv("rmEndPoint");
+    amEndpoint = System.getenv("schedulerEndPoint"); // should be schedulerEndPoint, amEndpoint.
     conf.set(YarnConfiguration.RM_ADDRESS, rmEndpoint);
     conf.set(YarnConfiguration.RM_SCHEDULER_ADDRESS, amEndpoint);
     // Set NM/RM max-wait to respective intervals, so that the underlying ipc.Client only retries once.


### PR DESCRIPTION
1. workaround about the security HDFS with insecurity DynoYarn container to download simulatedFatJar.
2. unset APPLICATION_WEB_PROXY_BASE to display RM normally.
3. change /grid to $base/tmp due to /grid may not exist.